### PR TITLE
Vehicle controlled logging

### DIFF
--- a/can_logger_client.py
+++ b/can_logger_client.py
@@ -116,6 +116,7 @@ class CanLogger:
     def _start_logging(self):
         if self.logging:
             return
+        self.flag_this_log = False
         start_time = datetime.now()
         self.file_name = (
             start_time.strftime("%Y-%m-%d_%H.%M.%S_") + self.channel + ".asc"
@@ -134,7 +135,6 @@ class CanLogger:
         sleep(0.1)  # prevent race condition with writing thread.
         self.writer.stop()
         if self.flag_this_log:
-            self.flag_this_log = False
             os.replace(self.file_path, f"{self.log_dir}/flagged/{self.file_name}")
 
     def _stats_publisher(self):

--- a/can_logger_client.py
+++ b/can_logger_client.py
@@ -131,6 +131,7 @@ class CanLogger:
         if not self.logging:
             return
         self.logging = False
+        sleep(0.1)  # prevent race condition with writing thread.
         self.writer.stop()
         if self.flag_this_log:
             self.flag_this_log = False

--- a/config.py
+++ b/config.py
@@ -39,3 +39,8 @@ vehicle_time_signal_name = "UnixTimeSeconds528"
 vehicle_gear_frame_id = "118"
 vehicle_gear_signal_name = "DI_gear"
 vehicle_gear_logging_states = ["DI_GEAR_D", "DI_GEAR_N", "DI_GEAR_R"]
+
+# This is used to control auto logging
+auto_logging_frame_id = "273"
+auto_logging_signal_name = "UI_frontFogSwitch"
+auto_logging_on_state = 0

--- a/config.py
+++ b/config.py
@@ -43,7 +43,7 @@ vehicle_gear_logging_states = ["DI_GEAR_D", "DI_GEAR_N", "DI_GEAR_R"]
 
 # This is used to control auto logging
 auto_logging_frame_id = "273"
-auto_logging_signal_name = "UI_frontFogSwitch"
+auto_logging_signal_name = "UI_rearWindowLockout"
 auto_logging_on_value = 1
 
 # This is used to flag a log for saving

--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ can_filter = [
     "ID186DIF_torque",
     "ID20CVCRIGHT_hvacRequest",
     "ID243VCRIGHT_hvacStatus",
+    "ID249SCCMLeftStalk",
     "ID257DIspeed",
     "ID266RearInverterPower",
     "ID273UI_vehicleControl",
@@ -43,4 +44,11 @@ vehicle_gear_logging_states = ["DI_GEAR_D", "DI_GEAR_N", "DI_GEAR_R"]
 # This is used to control auto logging
 auto_logging_frame_id = "273"
 auto_logging_signal_name = "UI_frontFogSwitch"
-auto_logging_on_state = 0
+auto_logging_on_value = 1
+
+# This is used to flag a log for saving
+flag_log_frame_id = "249"
+flag_log_signal_name = "SCCM_highBeamStalkStatus"
+flag_log_state = "PUSH"
+# Only flag when holding the signal for at least this duration
+flag_log_signal_duration = 0.8


### PR DESCRIPTION
This allows controlling logging features without opening the browser.

By default, for a TM3, it uses the Window Lock to enable auto logging (locked/blue = auto-logging on), and hold forward on the high beam stalk for > 0.8 seconds to flag a log (moves to ./flagged dir)